### PR TITLE
Ignore cancelled interact events and go after other plugins

### DIFF
--- a/src/com/acropolismc/play/sellstick/PlayerListener.java
+++ b/src/com/acropolismc/play/sellstick/PlayerListener.java
@@ -8,6 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -145,7 +146,7 @@ public class PlayerListener implements Listener {
 	}
 
 	@SuppressWarnings("deprecation")
-	@EventHandler
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
 	public void onUse(PlayerInteractEvent e) {
 		Player p = e.getPlayer();
 		// Gets item from Config.


### PR DESCRIPTION
This should make it compatible with lots of protection plugins that cancel the event interact event if the chest is protected in some way. The EventPriority.HIGH makes sure it goes after any listener that uses no priority (=NORMAL) or LOW/-EST.