### PR TITLE
Make Essentials an optional dependency

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,7 @@ main: com.acropolismc.play.sellstick.SellStick
 version: 8.0.9.0a
 author: shmkane
 website: https://github.com/shmkane/SellStick
-depend: [Vault, Essentials]
+depend: [Vault]
 softdepend: [Factions, Essentials, MassiveCore, LegacyFactions, ASkyBlock, PlotSquared]
 commands:
    sellstick:

--- a/src/com/acropolismc/play/sellstick/PlayerListener.java
+++ b/src/com/acropolismc/play/sellstick/PlayerListener.java
@@ -417,7 +417,7 @@ public class PlayerListener implements Listener {
 									// TryCatch incase something goes wrong
 
 								// Loop through the config
-								if (!StickConfig.instance.useEssentialsWorth) {
+								if (!StickConfig.instance.useEssentialsWorth || plugin.ess == null || !plugin.ess.isEnabled()) {
 									for (String key : PriceConfig.instance.getConfig().getConfigurationSection("prices")
 											.getKeys(false)) {
 

--- a/src/com/acropolismc/play/sellstick/SellStick.java
+++ b/src/com/acropolismc/play/sellstick/SellStick.java
@@ -17,21 +17,16 @@ import net.milkbowl.vault.economy.Economy;
 // @author shmkane
 public class SellStick extends JavaPlugin {
 
-	public Plugin essentialsPlugin;
 	public Essentials ess;
 	private static Economy econ = null;
 	private static final Logger log = Logger.getLogger("Minecraft");
 
 	public void onEnable() {
 		// Hook into essentials.
-		essentialsPlugin = Bukkit.getPluginManager().getPlugin("Essentials");
-		if (essentialsPlugin.isEnabled() && (essentialsPlugin instanceof Essentials)) {
+		if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
 			log.info("[Sellstick] Essentials found");
-			this.essentialsPlugin = (Essentials) essentialsPlugin;
+			ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
 		}
-
-		// Essentials
-		ess = (Essentials) essentialsPlugin;
 		
 		// Commands
 		this.getCommand("sellstick").setExecutor(new SellStickCommand(this));
@@ -108,7 +103,7 @@ public class SellStick extends JavaPlugin {
 		}
 
 		if (StickConfig.instance.useEssentialsWorth) {
-			if (essentialsPlugin == null || !essentialsPlugin.isEnabled()) {
+			if (ess == null || !ess.isEnabled()) {
 				log.warning("[Sellstick] Trying to use essentials worth but essentials not found!");
 			} else {
 				log.info("[Sellstick] Hooked into Essentials Worth");


### PR DESCRIPTION
This fixes that Essentials was required in order to run this plugin even though it's worth config wasn't even used.